### PR TITLE
Added new requirement file for rtd.org

### DIFF
--- a/espressodb/__init__.py
+++ b/espressodb/__init__.py
@@ -4,7 +4,7 @@
 from django import setup as _setup
 from django.conf import settings
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 DEFAULT_OPTIONS = {
     "DEBUG": True,

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,11 @@
+Django>=2.2.2
+django-extensions>=2.2.1
+django-bootstrap4>=0.0.6
+django-widget-tweaks>=1.4.5
+django-pandas>=0.6.1
+PyYAML>=3.13
+sphinx>=2.2.0
+recommonmark>=0.6.0
+sphinx_rtd_theme>=0.4.3
+sphinx-autodoc-typehints>=1.8.0
+sphinx-markdown-tables>=0.0.9


### PR DESCRIPTION
This is because apparently the espressodb module is force installed and 
thus the actual dependencies of espressodb are not installed.