### PR TITLE
Arxiv update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve (not all sections have to be present)
+title: "[BUG]"
+labels: bug
+assignees: ckoerber
+
+---
+
+## Describe the bug
+*A clear and concise description of what the bug is.*
+
+* *Is this related to the backend (how data is stored or searched for)?*
+* *Is this related to the frontend (how data is rendered)?*
+
+## To Reproduce
+*Steps to reproduce the behavior:*
+* *What are the settings*
+* *Which part seems to crash*
+* *Is it possible to share a traceback (e.g., if setting `DEBUG=True` is an option)*
+
+## Expected behavior
+*A clear and concise description of what you expected to happen.*
+
+## Screenshots
+*If applicable, add screenshots to help explain your problem.*
+
+
+## Additional context
+*Add any other context about the problem here.*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project (not all sections have to be present)
+title: "[FEATURE]"
+labels: enhancement
+assignees: ckoerber
+
+---
+
+## Is your feature request related to a problem? Please describe.
+*A clear and concise description of what the problem is. Ex. It would help if [...]*
+
+## Describe the solution you'd like
+*A clear and concise description of what you want to happen.*
+
+## Describe alternatives you've considered
+*A clear and concise description of any alternative solutions or features you've considered.*
+
+## Additional context
+*Add any other context or screenshots about the feature request here.*

--- a/doc-src/arXiv/Makefile
+++ b/doc-src/arXiv/Makefile
@@ -10,11 +10,12 @@ paper_body.tex: ../../paper.md
 	cp ../../paper.md paper.tex.md
 	sed -i.bak 's/\[@Kurth_2018]/\\cite{Kurth_2018}/' paper.tex.md
 	sed -i.bak 's/\[@Joubert:2018:AOE:3291656.3291732]/\\cite{Joubert:2018:AOE:3291656.3291732}/' paper.tex.md
-	sed -i.bak 's/\[@Berkowitz:2018gqe]/\\cite{Berkowitz:2018gqe}/' paper.tex.md
+	sed -i.bak 's/\[@8665785]/\\cite{8665785}/' paper.tex.md
 	sed -i.bak 's/\[@incite:2019; @incite:2020]/\\cite{incite:2019,incite:2020}/' paper.tex.md
 	sed -i.bak 's/\[@Nicholson:2018mwc; @Chang:2018uxx]/\\cite{Nicholson:2018mwc,Chang:2018uxx}/' paper.tex.md
 	sed -i.bak 's/\[@Berkowitz:2017vcp]/\\cite{Berkowitz:2017vcp}/' paper.tex.md
-	sed -i.bak 's/\[@Berkowitz:2018gqe; @Berkowitz:2017xna]/\\cite{Berkowitz:2018gqe,Berkowitz:2017xna}/' paper.tex.md
+	sed -i.bak 's/\[@8665785; @Berkowitz:2017xna]/\\cite{8665785,Berkowitz:2017xna}/' paper.tex.md
+	sed -i.bak 's/\[@10.1093\/nar\/gkt328]/\\cite{10.1093\/nar\/gkt328}/' paper.tex.md
 	sed -i.bak 's/# References//' paper.tex.md
 	pandoc -t latex -o paper_body.tex paper.tex.md
 	sed -i.bak 's:doc-src/_static/lattedb-example.png:lattedb-example.png:' paper_body.tex

--- a/doc-src/arXiv/arXiv.tex
+++ b/doc-src/arXiv/arXiv.tex
@@ -212,24 +212,42 @@
   %\hrule
   \sffamily\small
 
-  %{\bfseries DOI:} \href{XXX}{\color{linky}{TBD}}
+  {\bfseries DOI:} \href{https://doi.org/10.21105/joss.02007}{\color{linky}{10.21105/joss.02007}}
 
   \vspace{2mm}
 
   {\bfseries Software}
   \begin{itemize}
     \setlength\itemsep{0em}
-    \item \href{https://github.com/openjournals/joss-reviews/issues/1936}{\color{linky}{Review}} \ExternalLink
+    \item \href{https://github.com/openjournals/joss-reviews/issues/2007}{\color{linky}{Review}} \ExternalLink
     \item \href{https://github.com/callat-qcd/espressodb}{\color{linky}{EspressoDB}} \ExternalLink
     \item \href{https://github.com/callat-qcd/lattedb}{\color{linky}{LattedDB}} \ExternalLink
+    \item \href{https://doi.org/10.5281/zenodo.3677432}{\color{linky}{Archive}} \ExternalLink
   \end{itemize}
 
+  \hrule
+
+  \vspace{2mm}
+
+  {\bfseries Editor:}
+  
+  \href{https://luc.edu/cs/people/ftfaculty/gkt.shtml}{\color{linky}{George K. Thiruvathukal}} \ExternalLink
 
 
   \vspace{2mm}
 
+  {\bfseries Reviewers:}
+  \begin{itemize}
+    \setlength\itemsep{0em}
+    \item \href{https://github.com/remram44}{\color{linky}{@remram44}}
+    \item \href{https://github.com/ixjlyons}{\color{linky}{@ixjlyons}}
+  \end{itemize}
+
+  \vspace{2mm}
+
   {\bfseries Submitted:} 06 Dec. 2019\\
-  %{\bfseries Published:} XX XXX 20XX
+  {\bfseries Published:} 21 Feb. 2020\\
+
 
   \vspace{2mm}
   {\bfseries Licence}\\

--- a/doc-src/arXiv/use-case.tex
+++ b/doc-src/arXiv/use-case.tex
@@ -66,7 +66,7 @@ Compounding these challenges, the new computer Summit, is
 \emph{disruptively fast} compared to previous generations of leadership
 class computers. Full machine-to-machine, Summit is approximately 15
 times faster than Titan when applied to LQCD applications such as those
-carried out by CalLat \cite{Berkowitz:2018gqe}. While this is great for
+carried out by CalLat \cite{8665785}. While this is great for
 scientific throughput, it also means the management of the computational
 jobs has become unwieldy with the management models typically used for
 such computations: Summit churns through the computations so fast, and


### PR DESCRIPTION
This PR contains the changes to the [EspressoDB arXiv version which was updated on April 16](https://arxiv.org/abs/1912.03580) such that arXiv is on par with the JOSS release.

**Changes:**
* Citations
* JOSS meta

