### PR TITLE
Feature exclude models from admin

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Changes
+
+*Describe the big picture of your changes here*
+
+## Fixes
+
+*Is this PR related to existing issues? If so please, link them here*
+
+## Checklist
+
+*Put an `x` in the boxes that apply.
+You can also fill these out after creating the PR.
+Depending on the PR, not all boxes have to be checked to be merged in.
+Feel free to reach out if you have questions.*
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/callat-qcd/espressodb/blob/master/CONTRIBUTING.md) doc
+- [ ] Existing unit tests pass locally with my changes
+- [ ] I have added unit tests that prove my that my feature works
+- [ ] I have added necessary documentation
+
+## Further comments
+
+*If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...*

--- a/doc-src/customizations/index.rst
+++ b/doc-src/customizations/index.rst
@@ -1,0 +1,38 @@
+Customizing EspressoDB
+======================
+
+This section specifies your options to update EspressoDB's appearance.
+
+Admin page
+----------
+
+By default, the :meth:`espressodb.base.admin.register_admins` method.
+This method is called in each apps  :code:`admin.py`.
+For example `my_project/hamiltonian/admin.py` file looks like
+
+.. code-block:: python
+
+    from espressodb.base.admin import register_admins
+
+    register_admins("my_project.hamiltonian")
+
+Adding the :code:`exclude_models` key word argument to the method, prevents rendering models in the admin page.
+
+This feature can be used to customize your admin view for a specific model
+
+.. code-block:: python
+
+    from django.contrib.admin import register, ModelAdmin
+    from espressodb.base.admin import register_admins
+
+    from my_project.hamiltonian.models import Eigenvalue
+
+    # Render all but the Eigenvalue admin of my_project.hamiltonian using EspressoDB
+    register_admins("my_project.hamiltonian", exclude_models=["Eigenvalue"])
+
+    # Implement a custom admin for Eigenvalue
+    @register(Eigenvalue)
+    class NewEigenvalueAdmin(ModelAdmin):
+        pass
+
+See also the `Django admin reference <https://docs.djangoproject.com/en/dev/ref/contrib/admin/>`_ for more details

--- a/doc-src/customizations/index.rst
+++ b/doc-src/customizations/index.rst
@@ -16,7 +16,7 @@ For example `my_project/hamiltonian/admin.py` file looks like
 
     register_admins("my_project.hamiltonian")
 
-Adding the :code:`exclude_models` key word argument to the method, prevents rendering models in the admin page.
+Adding the :code:`exclude_models` keyword argument to the method, prevents rendering models in the admin page.
 
 This feature can be used to customize your admin view for a specific model
 

--- a/doc-src/index.rst
+++ b/doc-src/index.rst
@@ -18,5 +18,6 @@ Welcome to the documentation of `EspressoDB` -- an open source Python package fo
    example/index
    faq
    features/index
+   customizations/index
    api/index
    CONTRIBUTING

--- a/espressodb/__init__.py
+++ b/espressodb/__init__.py
@@ -2,7 +2,7 @@
 """Initializes minimal settings to launch EspressoDB
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 DEFAULT_OPTIONS = {
     "DEBUG": True,

--- a/espressodb/base/admin.py
+++ b/espressodb/base/admin.py
@@ -104,7 +104,7 @@ class ListViewAdmin(admin.ModelAdmin):
         return str(obj)
 
 
-def register_admins(app_name: str):
+def register_admins(app_name: str, exclude_models: Optional[List[str]] = None):
     """Tries to load all models from this app and registers :class:`ListViewAdmin` sites.
 
     Arguments:
@@ -112,11 +112,14 @@ def register_admins(app_name: str):
 
     Calls :meth:`admin.site.register` for all models within the specified app.
     """
+    exclude_models = exclude_models or []
+
     apps = [app for app in get_project_apps() if app.name == app_name]
 
     if len(apps) == 1:
         for model in apps[0].get_models():
-            admin.site.register(model, ListViewAdmin)
+            if model.__name__ not in exclude_models:
+                admin.site.register(model, ListViewAdmin)
     else:
         LOGGER.warning(
             "Was not able to locate app `%s`."

--- a/espressodb/base/admin.py
+++ b/espressodb/base/admin.py
@@ -109,6 +109,8 @@ def register_admins(app_name: str, exclude_models: Optional[List[str]] = None):
 
     Arguments:
         app_name: The name of the app.
+        exclude_models: Models contained in this app which should not appear on the admin
+            page. Uses the class name of the model.
 
     Calls :meth:`admin.site.register` for all models within the specified app.
     """

--- a/tests/espressodb_tests/espressodb_tests/customizations/__init__.py
+++ b/tests/espressodb_tests/espressodb_tests/customizations/__init__.py
@@ -1,0 +1,2 @@
+"""This module contains tests for customizations of EspressoDB
+"""

--- a/tests/espressodb_tests/espressodb_tests/customizations/admin.py
+++ b/tests/espressodb_tests/espressodb_tests/customizations/admin.py
@@ -1,0 +1,7 @@
+"""Admin pages for espressodb_tests.customizations models
+
+On default generates list view admins for all models
+"""
+from espressodb.base.admin import register_admins
+
+register_admins("espressodb_tests.customizations", exclude_models=["CA"])

--- a/tests/espressodb_tests/espressodb_tests/customizations/models.py
+++ b/tests/espressodb_tests/espressodb_tests/customizations/models.py
@@ -1,0 +1,27 @@
+# pylint: disable=C0103
+"""Example models for tests
+"""
+from django.db import models
+from espressodb.base.models import Base
+
+
+class CA(Base):
+    """Blank table with no columns
+    """
+
+    def __str__(self):
+        return f"A(pk={self.pk})"
+
+    def __repr__(self):
+        return str(self)
+
+
+class CB(Base):
+    """First many to many class
+    """
+
+    def __str__(self):
+        return f"B(pk={self.pk})"
+
+    def __repr__(self):
+        return str(self)

--- a/tests/espressodb_tests/espressodb_tests/customizations/tests.py
+++ b/tests/espressodb_tests/espressodb_tests/customizations/tests.py
@@ -1,0 +1,47 @@
+# pylint: disable=C0103
+"""Tests of customizations of EspressoDB
+"""
+from logging import getLogger
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+LOGGER = getLogger("espressodb")
+
+
+class AminPageTest(TestCase):
+    """Checks for customizations of the admin page
+    """
+
+    def setUp(self):
+        """Create a user for the test
+        """
+        self.username = "test user"
+        self.password = "admin1234"
+        user = User.objects.create(username=self.username)
+        user.is_staff = True
+        user.is_superuser = True
+        user.set_password(self.password)
+        user.save()
+
+    def test_model_excluded_from_admin(self):
+        """The admin.py file of this module excludes the CA model. This test checks if
+        only the CB model is found on the admin page.
+        """
+        login = self.client.login(username=self.username, password=self.password)
+        self.assertTrue(login)
+
+        response = self.client.get("/admin/")
+        self.assertEqual(response.status_code, 200)
+
+        app_context_data = [
+            app
+            for app in response.context_data["available_apps"]
+            if app["app_label"] == "customizations"
+        ]
+        self.assertEqual(len(app_context_data), 1)
+
+        admin_models = app_context_data[0]["models"]
+        self.assertEqual(len(admin_models), 1)
+        self.assertEqual(admin_models[0]["object_name"], "CB")

--- a/tests/espressodb_tests/espressodb_tests/init_check_tests/tests.py
+++ b/tests/espressodb_tests/espressodb_tests/init_check_tests/tests.py
@@ -24,7 +24,7 @@ class RunCheckTest(TestCase):
         """Sets the ESPRESSODB_INIT_CHECKS environment variable to zero to check if
         run_all_checks is called.
         """
-        os.environ.pop("ESPRESSODB_INIT_CHECKS")
+        os.environ.pop("ESPRESSODB_INIT_CHECKS", None)
 
         importlib.reload(espressodb_tests)
 

--- a/tests/espressodb_tests/settings.yaml
+++ b/tests/espressodb_tests/settings.yaml
@@ -3,5 +3,6 @@ PROJECT_APPS:
     - espressodb_tests.m2mtests
     - espressodb_tests.pre_save_tests
     - espressodb_tests.init_check_tests
+    - espressodb_tests.customizations
 ALLOWED_HOSTS: ["testserver", "localhost", "127.0.0.1"]
 DEBUG: True


### PR DESCRIPTION
## Changes

* Added method which allows to exclude models to appear on admin page.
This allows to easily exclude unwanted views or generate custom views without changing default `admin.py`s too much.
* Added this PR template to the repo
* Bumped version to `1.2.0` for future merge into master

## Fixes

Fixes #58 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/callat-qcd/espressodb/blob/master/CONTRIBUTING.md) doc
- [x] Existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my that my feature works
- [x] I have added necessary documentation

## Further comments

None
