### PR TITLE
[Feature] Navigation bar customization

### DIFF
--- a/doc-src/customizations/index.rst
+++ b/doc-src/customizations/index.rst
@@ -36,3 +36,53 @@ This feature can be used to customize your admin view for a specific model
         pass
 
 See also the `Django admin reference <https://docs.djangoproject.com/en/dev/ref/contrib/admin/>`_ for more details
+
+Navigation customizations
+-------------------------
+
+On default, EspressoDB renders navigation elements like app views, the documentation, admin links and others.
+It is possible to update the default rendering by `extending <https://docs.djangoproject.com/en/dev/ref/templates/language/#template-inheritance>`_ the :code:`base.html` template.
+
+The default navigation bar is implemented in :code:`espressodb/base/templates/base.html` by the following code (suppressing the HTML tags and classes)
+
+.. code-block:: html
+
+    <nav>
+        {% block nav %}
+        <!-- Logo -->
+        ...
+        <ul>
+            {% block nav-app-links %}
+            <!-- App links -->
+            ...
+            {% endblock nav-app-links %}
+            {% block nav-default-links %}
+            <!-- Default EspressoDB links (docs, populate, notifications, admin) -->
+            ...
+            {% endblock nav-default-links %}
+        </ul>
+        <ul>
+            <!-- Login/out links -->
+            ...
+        </ul>
+        {% endblock nav %}
+    </nav>
+
+To write your custom navigation bar implementation, you have to create a new :code:`base.html` template which extends EspressoDB's :code:`base.html` template.
+Within this template, you can update the template blocks such that the default content gets replaced by the new block you provide.
+For example, creating :code:`my_project/hamiltonian/templates/base.html` with the following code changes the existing app links to a single item of name `Link Name`.
+
+.. code-block:: html
+
+    {% extends 'base.html' %}
+
+    {% block nav-app-links %}
+    <li class="nav-item">
+        <a class="nav-link" href="{% url 'app:name' %}">Link Name</a>
+    </li>
+    {% endblock nav-app-links %}
+
+The :code:`{% url 'app:name' %}` templatetag looks up the :code:`urls.py` for the specified app and returns the URL for the view with the implemented name.
+
+.. Note::
+    EspressoDB uses `Bootstrap 4 navigation components <https://getbootstrap.com/docs/4.0/components/navs/>`_ to prettify the HTML view.

--- a/espressodb/base/templates/base.html
+++ b/espressodb/base/templates/base.html
@@ -28,6 +28,7 @@
 <body>
     <header>
         <nav class="navbar navbar-expand-sm navbar-light bg-light">
+            {% block nav %}
             <!-- Brand -->
             <a class="navbar-brand" href="{% url 'base:index' %}">
                 <img src="{% static 'logo.svg' %}" alt="{% project_name %}" style="height: 35px" class="align-top">
@@ -38,7 +39,11 @@
             <!-- Links -->
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav">
+                    {% block nav-app-links %}
                     {% render_link_list %}
+                    {% endblock nav-app-links %}
+                    {% block nav-default-links %}
+                    {% render_documentation_links %}
                     <li class="nav-item">
                         <a class="nav-link" href="{% url 'base:populate' %}">
                             <i class="fas fa-plus mx-1"></i>Populate
@@ -52,6 +57,7 @@
                         </a>
                     </li>
                     {% endif %}
+                    {% endblock nav-default-links %}
                 </ul>
                 <ul class="navbar-nav ml-auto">
                     {% if user.is_authenticated %}
@@ -68,6 +74,7 @@
                     {% endif %}
                 </ul>
             </div>
+            {% endblock nav %}
         </nav>
     </header>
     <main role="main">

--- a/espressodb/base/templates/documentation-links.html
+++ b/espressodb/base/templates/documentation-links.html
@@ -1,0 +1,12 @@
+{% if documentation %}
+<li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" href="#" id="navbardrop" data-toggle="dropdown">
+        <i class="fas fa-book mx-1"></i>Documentation
+    </a>
+    <div class="dropdown-menu">
+        {% for app_slug, app_name in documentation %}
+        <a class="dropdown-item" href="{% url 'documentation:details' app_slug %}">{{app_name}}</a>
+        {% endfor%}
+    </div>
+</li>
+{% endif %}

--- a/espressodb/base/templates/link-list.html
+++ b/espressodb/base/templates/link-list.html
@@ -10,15 +10,3 @@
     </div>
 </li>
 {% endfor %}
-{% if documentation %}
-<li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" id="navbardrop" data-toggle="dropdown">
-        <i class="fas fa-book mx-1"></i>Documentation
-    </a>
-    <div class="dropdown-menu">
-        {% for app_slug, app_name in documentation %}
-        <a class="dropdown-item" href="{% url 'documentation:details' app_slug %}">{{app_name}}</a>
-        {% endfor%}
-    </div>
-</li>
-{% endif %}

--- a/espressodb/base/templatetags/base_extras.py
+++ b/espressodb/base/templatetags/base_extras.py
@@ -24,10 +24,10 @@ register = template.Library()  # pylint: disable=C0103
 
 
 @register.inclusion_tag("link-list.html")
-def render_link_list(  # pylint: disable=R0914
+def render_link_list(
     exclude=("", "populate", "populate-result", "admin", "documentation")
-) -> Dict[str, Tuple[str, str]]:
-    """Renders all app and documentation page links
+) -> List[Tuple[str, str]]:
+    """Renders all app page links
 
     Arguments:
         exclude: The link names to exclude.
@@ -81,15 +81,30 @@ def render_link_list(  # pylint: disable=R0914
         else:
             urls[app_name] = [(link_name, reverse_name)]
 
+    context = {"urls": urls}
+
+    return context
+
+
+@register.inclusion_tag("documentation-links.html")
+def render_documentation_links() -> List[Tuple[str, str]]:
+    """Renders all app documentation page links
+
+    Returns:
+        Context with keys ``urls`` and ``documentation`` where each value is a list
+        of Tuples with the reverse url name and display name.
+
+    Ignores urls which do not result in a match.
+
+    Uses the template ``documentation-links.html``.
+    """
     documentation = []
 
     if "espressodb.documentation" in settings.INSTALLED_APPS:
         for app_slug, app in get_apps_slug_map().items():
             documentation.append((app_slug, get_app_name(app)))
 
-    context = {"urls": urls, "documentation": documentation}
-
-    return context
+    return {"documentation": documentation}
 
 
 def render_field(field: Field, instance_name: Optional[str] = None) -> str:

--- a/tests/espressodb_tests/espressodb_tests/customizations/templates/customized-index.html
+++ b/tests/espressodb_tests/espressodb_tests/customizations/templates/customized-index.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+
+{% block nav-default-links %}
+{% endblock nav-default-links %}

--- a/tests/espressodb_tests/espressodb_tests/customizations/urls.py
+++ b/tests/espressodb_tests/espressodb_tests/customizations/urls.py
@@ -1,0 +1,8 @@
+"""Views for the customizations app
+"""
+from django.urls import path
+
+from espressodb_tests.customizations.views import IndexView
+
+app_name = "customizations"
+urlpatterns = [path("", IndexView.as_view(), name="index")]

--- a/tests/espressodb_tests/espressodb_tests/customizations/views.py
+++ b/tests/espressodb_tests/espressodb_tests/customizations/views.py
@@ -1,0 +1,10 @@
+"""Views for the customizations app
+"""
+from espressodb.base.views import IndexView as BaseIndexView
+
+
+class IndexView(BaseIndexView):
+    """Index view of base app with different template which overrides default links
+    """
+
+    template_name = "customized-index.html"


### PR DESCRIPTION
## Changes

* Added three navbar  blocks to `base.html` template (`nav`, `nav-app-links` and `nav-default-links`) which allow customization of navbar
* Refactored `render_link_list ` to `render_link_list` and `render_documentation_links` to allow more customization

## Fixes

Fixes #64 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/callat-qcd/espressodb/blob/master/CONTRIBUTING.md) doc
- [x] Existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my that my feature works
- [x] I have added necessary documentation
