### PR TITLE
Issue 72 check consistency forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 __pycache__/
 .espressodb
-espressodb.egg-info/
+*.egg-info/
 .ipynb_checkpoints
 .eggs
 build/

--- a/espressodb/base/models.py
+++ b/espressodb/base/models.py
@@ -19,6 +19,7 @@ from django.template.defaultfilters import slugify
 from django.db.models.fields import Field
 from django.urls import reverse, Resolver404
 from django.apps.config import AppConfig
+from django.core.exceptions import ValidationError
 
 from django_pandas.managers import DataFrameManager
 
@@ -147,6 +148,20 @@ class Base(models.Model):
 
         Raise errors here if the model must fulfill checks.
         """
+
+    def clean(self):
+        """Calls super clean, check_consistency and check_m2m_consistency.
+
+        Consistency errors are wrapped as validation errors.
+        This ensures consistencies are properly captured in form validations and do not
+        raise errors berfore.
+        """
+        super().clean()
+        try:
+            self.check_consistency()
+            self.check_m2m_consistency()
+        except Exception as error:
+            raise ValidationError(message=str(error), params={"instance": self})
 
     def pre_save(self):
         """Method is called before save and before check consistency.

--- a/espressodb/base/models.py
+++ b/espressodb/base/models.py
@@ -150,7 +150,7 @@ class Base(models.Model):
         """
 
     def clean(self):
-        """Calls super clean, check_consistency and check_m2m_consistency.
+        """Calls super clean, check_consistency.
 
         Consistency errors are wrapped as validation errors.
         This ensures consistencies are properly captured in form validations and do not
@@ -159,7 +159,6 @@ class Base(models.Model):
         super().clean()
         try:
             self.check_consistency()
-            self.check_m2m_consistency()
         except Exception as error:
             raise ValidationError(message=str(error), params={"instance": self})
 

--- a/example/my_project/my_project/hamiltonian/tests/test_forms.py
+++ b/example/my_project/my_project/hamiltonian/tests/test_forms.py
@@ -34,7 +34,7 @@ class EigenvalueTest(TestCase):
             1. Form is_valid method calls check_consistency with expected arguments
         """
         data = {
-            "hamiltonian": self.hamiltonian,
+            "hamiltonian": self.hamiltonian.pk,
             "n_level": 0,
             "value": Decimal("0.0"),
         }
@@ -53,11 +53,12 @@ class EigenvalueTest(TestCase):
             2. Form is_valid method raises error if inconsistent as validation error
         """
         data = {
-            "hamiltonian": self.hamiltonian,
+            "hamiltonian": self.hamiltonian.pk,
             "n_level": 0,
             "value": Decimal("0.0"),
         }
-        self.assertTrue(EigenValueForm(data).is_valid())
+        form = EigenValueForm(data)
+        self.assertTrue(form.is_valid())
 
         data["n_level"] = 20
         form = EigenValueForm(data)

--- a/example/my_project/my_project/hamiltonian/tests/test_forms.py
+++ b/example/my_project/my_project/hamiltonian/tests/test_forms.py
@@ -1,0 +1,68 @@
+"""Tests for models specific for the Hamiltonians app
+"""
+from decimal import Decimal
+
+from unittest.mock import patch
+
+from django.forms import ModelForm
+from django.test import TestCase
+
+from my_project.hamiltonian.models import Hamiltonian, Contact, Eigenvalue
+
+
+class EigenValueForm(ModelForm):
+    class Meta:
+        model = Eigenvalue
+        fields = ["hamiltonian", "n_level", "value"]
+
+
+class EigenvalueTest(TestCase):
+    """Tests specific for the Eigenvalue forms
+    """
+
+    def setUp(self):
+        """Creates a hamiltonian for the checks.
+        """
+        Contact.objects.create(n_sites=10, spacing=Decimal("0.1"), c=Decimal("-1.0"))
+        # Store base class to have successful attribute comparison
+        self.hamiltonian = Hamiltonian.objects.first()
+
+    def test_form_checks_consistency(self):
+        """Tests wether entering eigenvalue using forms checks consistency.
+
+        Tests:
+            1. Form is_valid method calls check_consistency with expected arguments
+        """
+        data = {
+            "hamiltonian": self.hamiltonian,
+            "n_level": 0,
+            "value": Decimal("0.0"),
+        }
+        form = EigenValueForm(data)
+
+        with patch.object(Eigenvalue, "check_consistency") as mocked_check_consistency:
+            form.is_valid()
+
+        mocked_check_consistency.assert_called()
+
+    def test_form_raises_consistency_error_as_validation_error(self):
+        """Tests wether entering eigenvalue using forms checks consistency.
+
+        Tests:
+            1. Form is_valid method raises no error if valid
+            2. Form is_valid method raises error if inconsistent as validation error
+        """
+        data = {
+            "hamiltonian": self.hamiltonian,
+            "n_level": 0,
+            "value": Decimal("0.0"),
+        }
+        self.assertTrue(EigenValueForm(data).is_valid())
+
+        data["n_level"] = 20
+        form = EigenValueForm(data)
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors, {"__all__": ["Eigenstate index larger than matrix allows."]}
+        )


### PR DESCRIPTION
## Changes

This PR wraps the clean method around `check_consistency` to prevent consistency errors crashing the web app if users provide inconsistent input.

## Fixes

#72 

## Checklist

*Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
Depending on the PR, not all boxes have to be checked to be merged in.
Feel free to reach out if you have questions.*

- [x] I have read the [CONTRIBUTING](https://github.com/callat-qcd/espressodb/blob/master/CONTRIBUTING.md) doc
- [x] Existing unit tests pass locally with my changes
- [x] I have added unit tests that prove that my feature works
- [ ] I have added necessary documentation

