### PR TITLE
Issue 74 migration checks

### DIFF
--- a/doc-src/features/init-checks.rst
+++ b/doc-src/features/init-checks.rst
@@ -59,13 +59,18 @@ The check function :func:`espressodb.management.checks.run_all_checks` is called
 
 This function is run whenever you import your project.
 
-EspressoDB projects before version 1.1.0 do not contain the above ``if`` statement.
-Copy these lines in your project's ``_init()`` function to allow automated checks.
+.. note::
+    The method :func:`~espressodb.management.checks.run_all_checks` wraps :func:`~espressodb.management.checks.migrations.check_model_state` and :func:`~espressodb.management.checks.migrations.check_migration_state`.
+    If you do not want to check the state of migrations all apps, you can provide a list of apps to exclude to :func:`~espressodb.management.checks.migrations.check_migration_state`.
 
-This ``_init()`` function is the place where you can globally change the default behavior for checks.
-For example, to turn on checks if the ``ESPRESSODB_INIT_CHECKS`` is not set, change the ``if`` condition to
+.. warning::
+    EspressoDB projects before version 1.1.0 do not contain the above ``if`` statement.
+    Copy these lines in your project's ``_init()`` function to allow automated checks.
 
-.. code ::
+    This ``_init()`` function is the place where you can globally change the default behavior for checks.
+    For example, to turn on checks if the ``ESPRESSODB_INIT_CHECKS`` is not set, change the ``if`` condition to
 
-    if os.environ.get("ESPRESSODB_INIT_CHECKS", "1") != "0":
-        ...
+    .. code ::
+
+        if os.environ.get("ESPRESSODB_INIT_CHECKS", "1") != "0":
+            ...

--- a/tests/migration_tests/tests/test_state1.py
+++ b/tests/migration_tests/tests/test_state1.py
@@ -26,7 +26,7 @@ class MigrationTest(ProjectSetup, TestCase):
     def test_02_migration_state():
         """Checks if all migrations agree with database state
         """
-        check_migration_state()
+        check_migration_state(exclude=["auth"])
 
 
 if __name__ == "__main__":

--- a/tests/migration_tests/tests/test_state2.py
+++ b/tests/migration_tests/tests/test_state2.py
@@ -27,7 +27,7 @@ class MigrationTest(ProjectSetup, TestCase):
     def test_02_migration_state():
         """Checks if all migrations agree with database state
         """
-        check_migration_state()
+        check_migration_state(exclude=["auth"])
 
 
 if __name__ == "__main__":

--- a/tests/migration_tests/tests/test_state3.py
+++ b/tests/migration_tests/tests/test_state3.py
@@ -27,7 +27,7 @@ class MigrationTest(ProjectSetup, TestCase):
         """Checks if all migrations agree with database state
         """
         with self.assertRaises(MigrationStateError):
-            check_migration_state()
+            check_migration_state(exclude=["auth"])
 
 
 if __name__ == "__main__":

--- a/tests/migration_tests/tests/test_state4.py
+++ b/tests/migration_tests/tests/test_state4.py
@@ -27,7 +27,7 @@ class MigrationTest(ProjectSetup, TestCase):
         """Checks if all migrations agree with database state
         """
         with self.assertRaises(MigrationStateError):
-            check_migration_state()
+            check_migration_state(exclude=["auth"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

Added optional `exclude` kwarg to `check_migration_state` to ignore certain apps when checking migrations.

## Fixes

#74 

## Checklist

*Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
Depending on the PR, not all boxes have to be checked to be merged in.
Feel free to reach out if you have questions.*

- [x] I have read the [CONTRIBUTING](https://github.com/callat-qcd/espressodb/blob/master/CONTRIBUTING.md) doc
- [x] Existing unit tests pass locally with my changes
- [x] I have added unit tests that prove that my feature works
- [x] I have added necessary documentation

