### PR TITLE
Added default auto field attribute notifications app config

### DIFF
--- a/espressodb/__init__.py
+++ b/espressodb/__init__.py
@@ -2,7 +2,7 @@
 """Initializes minimal settings to launch EspressoDB
 """
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 DEFAULT_OPTIONS = {
     "DEBUG": True,

--- a/espressodb/notifications/apps.py
+++ b/espressodb/notifications/apps.py
@@ -6,3 +6,4 @@ class NotificationsConfig(AppConfig):
     name = "espressodb.notifications"
     verbose_name = "Notifications"
     label = "notifications"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
## Changes

Added default auto field attribute to notifications app config (`default_auto_field = "django.db.models.AutoField"`)

## Fixes
This resolves #80. I have verified that this fix removes the warning for Django 3.2, is compatible to previous versions, and 
does not create new migrations for existing projects (changing it to `BigAutoField` would demand new migrations).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/callat-qcd/espressodb/blob/master/CONTRIBUTING.md) doc
- [x] Existing unit tests pass locally with my changes
- [x] I have added unit tests that prove that my feature works (existing tests check it)
- [x] I have added necessary documentation (no documentation need as this happens behind the scenes and is in line with Django)
